### PR TITLE
added delta_ellipcity to TrapInstantCapture

### DIFF
--- a/arcticpy/src/ccd.py
+++ b/arcticpy/src/ccd.py
@@ -1,7 +1,8 @@
 import numpy as np
 
+from arcticpy.src.dictable import Dictable
 
-class CCDPhase(object):
+class CCDPhase(Dictable):
     def __init__(self, full_well_depth=1e4, well_notch_depth=0.0, well_fill_power=1.0):
         self.full_well_depth = full_well_depth
         self.well_notch_depth = well_notch_depth

--- a/arcticpy/src/dictable.py
+++ b/arcticpy/src/dictable.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 
 from autoconf.class_path import get_class_path, get_class
 
@@ -93,6 +94,39 @@ class Dictable:
                 in cls_dict.items()
             }
         )
+
+    @classmethod
+    def from_json(cls, file_path: str) -> "Dictable":
+        """
+        Load the dictable object to a .json file, whereby all attributes are converted from the .json file's dictionary
+        representation to create the instance of the object
+
+        A json file of the instance can be created from the .json file via the `output_to_json` method.
+
+        Parameters
+        ----------
+        file_path
+            The path to the .json file that the dictionary representation of the object is loaded from.
+        """
+        with open(file_path, "r+") as f:
+            cls_dict = json.load(f)
+
+        return cls.from_dict(cls_dict=cls_dict)
+
+    def output_to_json(self, file_path: str):
+        """
+        Output the dictable object to a .json file, whereby all attributes are converted to a dictionary representation
+        first.
+
+        An instane of the object can be created from the .json file via the `from_json` method.
+
+        Parameters
+        ----------
+        file_path
+            The path to the .json file that the dictionary representation of the object is written too.
+        """
+        with open(file_path, "w+") as f:
+            json.dump(self.dict(), f, indent=4)
 
     def __eq__(self, other):
         return self.dict() == other.dict()

--- a/arcticpy/src/dictable.py
+++ b/arcticpy/src/dictable.py
@@ -1,0 +1,98 @@
+import inspect
+
+from autoconf.class_path import get_class_path, get_class
+
+
+def as_dict(
+        obj
+):
+    if isinstance(
+            obj, list
+    ):
+        return list(map(
+            as_dict,
+            obj
+        ))
+    if obj.__class__.__module__ == 'builtins':
+        return obj
+    argument_dict = {
+        arg: getattr(
+            obj, arg
+        )
+        for arg
+        in inspect.getfullargspec(
+            obj.__init__
+        ).args[1:]
+    }
+    return {
+        "type": get_class_path(
+            obj.__class__
+        ),
+        **{
+            key: as_dict(value)
+            for key, value
+            in argument_dict.items()
+        }
+    }
+
+
+class Dictable:
+    def dict(self) -> dict:
+        """
+        A dictionary representation of the instance comprising a type
+        field which contains the entire class path by which the type
+        can be imported and constructor arguments.
+        """
+        return as_dict(self)
+
+    @staticmethod
+    def from_dict(
+            cls_dict
+    ):
+        """
+        Instantiate an instance of a class from its dictionary representation.
+
+        Parameters
+        ----------
+        cls_dict
+            A dictionary representation of the instance comprising a type
+            field which contains the entire class path by which the type
+            can be imported and constructor arguments.
+
+        Returns
+        -------
+        An instance of the geometry profile specified by the type field in
+        the cls_dict
+        """
+        if isinstance(
+                cls_dict,
+                list
+        ):
+            return list(map(
+                Dictable.from_dict,
+                cls_dict
+            ))
+        if not isinstance(
+                cls_dict,
+                dict
+        ):
+            return cls_dict
+
+        cls = get_class(
+            cls_dict.pop(
+                "type"
+            )
+        )
+        # noinspection PyArgumentList
+        return cls(
+            **{
+                name: Dictable.from_dict(
+                    value
+                )
+                for name, value
+                in cls_dict.items()
+            }
+        )
+
+    def __eq__(self, other):
+        return self.dict() == other.dict()

--- a/arcticpy/src/roe.py
+++ b/arcticpy/src/roe.py
@@ -1,11 +1,13 @@
 import numpy as np
 
+from arcticpy.src.dictable import Dictable
+
 roe_type_standard = 0
 roe_type_charge_injection = 1
 roe_type_trap_pumping = 2
 
 
-class ROE(object):
+class ROE(Dictable):
     def __init__(
         self,
         dwell_times=[1.0],

--- a/arcticpy/src/traps.py
+++ b/arcticpy/src/traps.py
@@ -20,6 +20,28 @@ class TrapInstantCapture(AbstractTrap):
         self.fractional_volume_none_exposed = fractional_volume_none_exposed
         self.fractional_volume_full_exposed = fractional_volume_full_exposed
 
+    @property
+    def delta_ellipticity(self):
+
+        a = 0.05333
+        d_a = -0.03357
+        d_p = 1.628
+        d_w = 0.2951
+        g_a = 0.09901
+        g_p = 0.4553
+        g_w = 0.4132
+
+        return 4.0 * self.density * (
+            a
+            + d_a * (np.arctan((np.log10(self.release_timescale) - d_p) / d_w))
+            + (
+                g_a
+                * np.exp(
+                    -((np.log10(self.release_timescale) - g_p) ** 2.0) / (2 * g_w ** 2.0)
+                )
+            )
+        )
+
 
 class TrapSlowCapture(AbstractTrap):
     def __init__(self, density=1.0, release_timescale=1.0, capture_timescale=0.0):

--- a/arcticpy/src/traps.py
+++ b/arcticpy/src/traps.py
@@ -7,6 +7,9 @@ class AbstractTrap(Dictable):
         self.density = density
         self.release_timescale = release_timescale
 
+    @property
+    def delta_ellipticity(self):
+        raise NotImplementedError
 
 class TrapInstantCapture(AbstractTrap):
     def __init__(

--- a/arcticpy/src/traps.py
+++ b/arcticpy/src/traps.py
@@ -1,7 +1,8 @@
 import numpy as np
 
+from arcticpy.src.dictable import Dictable
 
-class AbstractTrap(object):
+class AbstractTrap(Dictable):
     def __init__(self, density=1.0, release_timescale=1.0):
         self.density = density
         self.release_timescale = release_timescale
@@ -10,7 +11,7 @@ class AbstractTrap(object):
 class TrapInstantCapture(AbstractTrap):
     def __init__(
         self,
-        density=1.0,
+        density:float=1.0,
         release_timescale=1.0,
         fractional_volume_none_exposed=0.0,
         fractional_volume_full_exposed=0.0,

--- a/test/files/.gitignore
+++ b/test/files/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/test_arcticpy.py
+++ b/test/test_arcticpy.py
@@ -782,7 +782,28 @@ class TestCTIModelForHSTACS:
 
 class TestDictable:
 
-    def test__trap_instant_capture__dictable(self):
+
+    def test__ccd_is_dictable(self):
+
+        json_file = path.join(
+            "{}".format(path.dirname(path.realpath(__file__))), "files", "ccd.json"
+        )
+
+        ccd = cti.CCDPhase(full_well_depth=1.0, well_notch_depth=2.0, well_fill_power=3.0)
+
+        with open(json_file, "w+") as f:
+            json.dump(ccd.dict(), f, indent=4)
+
+        with open(json_file, "r+") as f:
+            ccd_load_dict = json.load(f)
+
+        ccd_load = cti.CCDPhase.from_dict(ccd_load_dict)
+
+        assert ccd_load.full_well_depth == 1.0
+        assert ccd_load.well_notch_depth == 2.0
+        assert ccd_load.well_fill_power == 3.0
+
+    def test__trap_is_dictable(self):
 
         json_file = path.join(
             "{}".format(path.dirname(path.realpath(__file__))), "files", "trap.json"

--- a/test/test_arcticpy.py
+++ b/test/test_arcticpy.py
@@ -5,10 +5,11 @@ from urllib.request import urlretrieve
 path = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(path, ".."))
 import arcticpy as cti
+import json
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-import matplotlib.pyplot as plt
-
+from os import path
 
 class TestCompareOldArCTIC:
     def test__add_cti__single_pixel__vary_express__compare_old_arctic(self):
@@ -777,6 +778,28 @@ class TestCTIModelForHSTACS:
             assert ccd.phases[0].full_well_depth == 84700
             assert ccd.phases[0].well_notch_depth == 0.0
             assert ccd.phases[0].well_fill_power == 0.478
+
+
+class TestDictable:
+
+    def test__trap_instant_capture__dictable(self):
+
+        json_file = path.join(
+            "{}".format(path.dirname(path.realpath(__file__))), "files", "trap.json"
+        )
+
+        trap = cti.TrapInstantCapture(density=1.0, release_timescale=2.0)
+
+        with open(json_file, "w+") as f:
+            json.dump(trap.dict(), f, indent=4)
+
+        with open(json_file, "r+") as f:
+            trap_load_dict = json.load(f)
+
+        trap_load = cti.TrapInstantCapture.from_dict(trap_load_dict)
+
+        assert trap_load.density == 1.0
+        assert trap_load.release_timescale == 2.0
 
 
 def run_demo():


### PR DESCRIPTION
Added the delta requirement of a trap to the TrapInstantCapture class:

```
    @property
    def delta_ellipticity(self):

        a = 0.05333
        d_a = -0.03357
        d_p = 1.628
        d_w = 0.2951
        g_a = 0.09901
        g_p = 0.4553
        g_w = 0.4132

        return 4.0 * self.density * (
            a
            + d_a * (np.arctan((np.log10(self.release_timescale) - d_p) / d_w))
            + (
                g_a
                * np.exp(
                    -((np.log10(self.release_timescale) - g_p) ** 2.0) / (2 * g_w ** 2.0)
                )
            )
        )
```


EDIT:


I have extended this PR to make it so that traps and CCD's are `Dictable`, e.g.:

```
from arcticpy.src.dictable import Dictable

class AbstractTrap(Dictable):
```

This basically just means we can easily write them to dictionaries and therefore to .json files. Probably not important for arctic, but helps with PyAutoCTI as we need to save the models we use to simulate datasets.