### PR TITLE
fixes due to changes in gcc/glibc; typo in url [WIP]

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,7 +105,7 @@ int run_benchmark() {
     FILE* f = fopen(filename, "r");
     if (!f) {
         const char* command =
-            "wget thttp://www.astro.dur.ac.uk/~rjm/ArCTIc/hst_acs_10_col.txt";
+            "wget http://www.astro.dur.ac.uk/~rjm/ArCTIc/hst_acs_10_col.txt";
         printf("%s\n", command);
         int status = system(command);
         if (status != 0) exit(status);

--- a/src/traps.cpp
+++ b/src/traps.cpp
@@ -8,6 +8,7 @@
 #include <math.h>
 
 #include <valarray>
+#include <limits>
 
 #include "util.hpp"
 

--- a/test/catch2/catch.hpp
+++ b/test/catch2/catch.hpp
@@ -10819,6 +10819,11 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
+
+    // (dirty) fix for issue that constant ahs been renamed in newer glibc (TODO alternatively correct name)
+    // https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=85e84fe53699fe9e392edffa993612ce08b2954a;hb=HEAD
+    #undef MINSIGSTKSZ
+    #define MINSIGSTKSZ 32768
     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
 
     static SignalDefs signalDefs[] = {


### PR DESCRIPTION
fixes necessary due to updates in glibc  (WIP since only dirty fix of renaming/redefinition issue of (former) constant cf. inline comments)